### PR TITLE
MISC - revision del token de acceso

### DIFF
--- a/src/controller/auth/auth.ts
+++ b/src/controller/auth/auth.ts
@@ -6,6 +6,6 @@ const globals = require('../../globals');
 export async function searchToken(id) {
     const db = globals.get(CONSTANTS.CLIENT_DB);
     const collection = db.collection(CONSTANTS.COLLECTION.AUTHAPPS);
-    const registroDelToken = await collection.findOne({ token: objectId(id) });
+    const registroDelToken = await collection.findOne({ token: id });
     return registroDelToken;
 }


### PR DESCRIPTION
Se quito el objectId ya que el id que viene por parámetro (el token de acceso) es un string y de esa forma se encuentra almacenado en la BD. 
Es necesario tener que implementar una nueva variable de entorno SERVER_AUTH ya que la misma no existe en "process.env" y no se hacen los chequeos necesarios para verificar si se esta accediendo con un token y si es correcto. 